### PR TITLE
Downgrade go version to 1.23.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # IDE files
 .idea/
 .vscode/
+# Vendors
+vendor/
 # Binaries for programs and plugins
 bin/
 *.exe

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qdrant/go-commons
 
-go 1.24.0
+go 1.23.4
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
Our other projects uses that go version. We should not force them to update for this dependency.