### PR TITLE
Improve wrapped gRPC errors

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -25,7 +25,9 @@ jobs:
           files=$(gofmt -l .) && echo $files && [ -z "$files" ]
 
       - name: Golang CI Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.4.0
 
   unit-tests:
     name: Unit Tests

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,33 +1,50 @@
-run:
-  timeout: 10m
-issues:
-  exclude-files:
-  - "generated.*\\.go$"
+version: "2"
 linters:
   enable:
-  - gci
-  - goconst
-  - gofmt
-  - goimports
-  - unparam
-  - importas
-  - bodyclose
-  - containedctx
-  - contextcheck
-  - errorlint
-  - nilerr
-  - promlinter
-  - sloglint
-  - testifylint
-  - unparam
-  - usestdlibvars
-linters-settings:
-  gci:
-    sections:
-    - standard # Standard section: captures all standard packages.
-    - default # Default section: contains all imports that could not be matched to another section type.
-    - prefix(github.com/qdrant) # Custom section: groups all imports with the specified Prefix.
-  importas:
-    alias:
-    - pkg: ^k8s\.io/apimachinery/pkg/apis/(\w+)/(v[\w\d]+)$
-      alias: $1$2
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - errorlint
+    - goconst
+    - importas
+    - nilerr
+    - promlinter
+    - sloglint
+    - testifylint
+    - unparam
+    - usestdlibvars
+  settings:
+    importas:
+      alias:
+        - pkg: ^k8s\.io/apimachinery/pkg/apis/(\w+)/(v[\w\d]+)$
+          alias: $1$2
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - generated.*\.go$
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/qdrant) # Custom section: groups all imports with the specified Prefix.
+  exclusions:
+    generated: lax
+    paths:
+      - generated.*\.go$
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
In the interceptor stack those are capture as gRPC status, not error, loosing the metadata, which we want to preserve.
Invert order (old to new) to be compatible with loggers.

Updated linter version to be able to run it locally as well.