### PR TITLE
chore: add dependabot cooldown configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `cooldown: default-days: 7` to all Dependabot update entries
- Delays version updates by 7 days after release to reduce risk of regressions and supply chain attacks
- Does not affect security updates (those still come immediately)

Ref: https://docs.zizmor.sh/audits/#dependabot-cooldown